### PR TITLE
Fixed issue with QuerySelector

### DIFF
--- a/src/joint.dia.link.js
+++ b/src/joint.dia.link.js
@@ -1105,7 +1105,7 @@ joint.dia.LinkView = joint.dia.CellView.extend({
 
         if (end.id) {
             args[i] = this.paper.findViewByModel(end.id);
-            args[i+1] = end.selector && args[i].el.querySelector(end.selector);
+            args[i+1] = end.selector && args[i].$el.find(end.selector)[0];
         }
 
         function validateConnectionArgs(cellView, magnet) {


### PR DESCRIPTION
It sometimes happened to me that when I dragged new Link from a port the validation of magnets was wrong. It was caused by wrong behavior of native `querySelector` method. Using jQuery `find` fixed it.
